### PR TITLE
fix multiselect and select value validation for edited product

### DIFF
--- a/module/attribute/src/Domain/Query/OptionQueryInterface.php
+++ b/module/attribute/src/Domain/Query/OptionQueryInterface.php
@@ -34,6 +34,13 @@ interface OptionQueryInterface
 
     /**
      * @param AttributeId $attributeId
+     *
+     * @return array
+     */
+    public function getOptions(AttributeId $attributeId): array;
+
+    /**
+     * @param AttributeId $attributeId
      * @param Language    $language
      *
      * @return DataSetInterface

--- a/module/attribute/src/Infrastructure/Provider/Strategy/OptionAttributeValueConstraintStrategy.php
+++ b/module/attribute/src/Infrastructure/Provider/Strategy/OptionAttributeValueConstraintStrategy.php
@@ -17,7 +17,6 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Constraints\Collection;
 use Ergonode\Attribute\Domain\Query\OptionQueryInterface;
-use Ergonode\Core\Domain\ValueObject\Language;
 
 /**
  */
@@ -55,11 +54,11 @@ class OptionAttributeValueConstraintStrategy implements AttributeValueConstraint
     {
         $multiple = $attribute instanceof MultiSelectAttribute;
 
-        $choices = array_keys($this->query->getList($attribute->getId(), new Language('en')));
+        $options = $this->query->getOptions($attribute->getId());
 
         return new Collection([
             'value' => [
-                new Choice(['choices' => $choices, 'multiple' => $multiple]),
+                new Choice(['choices' => $options, 'multiple' => $multiple]),
             ],
         ]);
     }

--- a/module/attribute/src/Persistence/Dbal/Query/DbalOptionQuery.php
+++ b/module/attribute/src/Persistence/Dbal/Query/DbalOptionQuery.php
@@ -68,12 +68,29 @@ class DbalOptionQuery implements OptionQueryInterface
      *
      * @return array
      */
+    public function getOptions(AttributeId $attributeId): array
+    {
+        $qb = $this->connection->createQueryBuilder();
+
+        return $qb->select('id')
+            ->from(self::TABLE_OPTIONS, 'o')
+            ->where($qb->expr()->eq('attribute_id', ':attribute'))
+            ->setParameter(':attribute', $attributeId->getValue())
+            ->execute()
+            ->fetchAll(\PDO::FETCH_COLUMN);
+    }
+
+    /**
+     * @param AttributeId $attributeId
+     *
+     * @return array
+     */
     public function getAll(AttributeId $attributeId): array
     {
         $qb = $this->getQuery();
 
         $records = $qb
-            ->select('o. id, o.key as code, value_id')
+            ->select('o.id, o.key as code, value_id')
             ->andWhere($qb->expr()->eq('o.attribute_id', ':id'))
             ->setParameter(':id', $attributeId->getValue())
             ->orderBy('o.key')

--- a/module/attribute/tests/Infrastructure/Provider/Strategy/DateAttributeValueConstraintStrategyTest.php
+++ b/module/attribute/tests/Infrastructure/Provider/Strategy/DateAttributeValueConstraintStrategyTest.php
@@ -8,33 +8,33 @@ declare(strict_types = 1);
 
 namespace Ergonode\Attribute\Tests\Infrastructure\Provider\Strategy;
 
-use Ergonode\Attribute\Domain\Entity\AbstractAttribute;
-use Ergonode\Attribute\Domain\Entity\Attribute\PriceAttribute;
-use PHPUnit\Framework\MockObject\MockObject;
+use Ergonode\Attribute\Infrastructure\Provider\Strategy\DateAttributeValueConstraintStrategy;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Ergonode\Attribute\Domain\Entity\Attribute\DateAttribute;
+use Ergonode\Attribute\Domain\Entity\AbstractAttribute;
 use Symfony\Component\Validator\Constraints\Collection;
-use Ergonode\Attribute\Infrastructure\Provider\Strategy\PriceAttributeValueConstraintStrategy;
 
 /**
  */
-class PriceAttributeValueConstraintStrategyTest extends TestCase
+class DateAttributeValueConstraintStrategyTest extends TestCase
 {
     /**
-     * @var PriceAttributeValueConstraintStrategy|MockObject
+     * @var DateAttributeValueConstraintStrategy|MockObject
      */
-    private PriceAttributeValueConstraintStrategy $strategy;
+    private DateAttributeValueConstraintStrategy $strategy;
 
     /**
-     * @var PriceAttribute|MockObject
+     * @var DateAttribute|MockObject
      */
-    private PriceAttribute $attribute;
+    private DateAttribute $attribute;
 
     /**
      */
     protected function setUp(): void
     {
-        $this->strategy = new PriceAttributeValueConstraintStrategy();
-        $this->attribute = $this->createMock(PriceAttribute::class);
+        $this->strategy = new DateAttributeValueConstraintStrategy();
+        $this->attribute = $this->createMock(DateAttribute::class);
     }
 
     /**

--- a/module/attribute/tests/Infrastructure/Provider/Strategy/ImageAttributeValueConstraintStrategyTest.php
+++ b/module/attribute/tests/Infrastructure/Provider/Strategy/ImageAttributeValueConstraintStrategyTest.php
@@ -8,33 +8,33 @@ declare(strict_types = 1);
 
 namespace Ergonode\Attribute\Tests\Infrastructure\Provider\Strategy;
 
-use Ergonode\Attribute\Domain\Entity\AbstractAttribute;
-use Ergonode\Attribute\Domain\Entity\Attribute\PriceAttribute;
-use PHPUnit\Framework\MockObject\MockObject;
+use Ergonode\Attribute\Infrastructure\Provider\Strategy\ImageAttributeValueConstraintStrategy;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Ergonode\Attribute\Domain\Entity\Attribute\ImageAttribute;
+use Ergonode\Attribute\Domain\Entity\AbstractAttribute;
 use Symfony\Component\Validator\Constraints\Collection;
-use Ergonode\Attribute\Infrastructure\Provider\Strategy\PriceAttributeValueConstraintStrategy;
 
 /**
  */
-class PriceAttributeValueConstraintStrategyTest extends TestCase
+class ImageAttributeValueConstraintStrategyTest extends TestCase
 {
     /**
-     * @var PriceAttributeValueConstraintStrategy|MockObject
+     * @var ImageAttributeValueConstraintStrategy|MockObject
      */
-    private PriceAttributeValueConstraintStrategy $strategy;
+    private ImageAttributeValueConstraintStrategy $strategy;
 
     /**
-     * @var PriceAttribute|MockObject
+     * @var ImageAttribute|MockObject
      */
-    private PriceAttribute $attribute;
+    private ImageAttribute $attribute;
 
     /**
      */
     protected function setUp(): void
     {
-        $this->strategy = new PriceAttributeValueConstraintStrategy();
-        $this->attribute = $this->createMock(PriceAttribute::class);
+        $this->strategy = new ImageAttributeValueConstraintStrategy();
+        $this->attribute = $this->createMock(ImageAttribute::class);
     }
 
     /**

--- a/module/attribute/tests/Infrastructure/Provider/Strategy/NumericAttributeValueConstraintStrategyTest.php
+++ b/module/attribute/tests/Infrastructure/Provider/Strategy/NumericAttributeValueConstraintStrategyTest.php
@@ -8,33 +8,33 @@ declare(strict_types = 1);
 
 namespace Ergonode\Attribute\Tests\Infrastructure\Provider\Strategy;
 
-use Ergonode\Attribute\Domain\Entity\AbstractAttribute;
-use Ergonode\Attribute\Domain\Entity\Attribute\PriceAttribute;
+use Ergonode\Attribute\Infrastructure\Provider\Strategy\NumericAttributeValueConstraintStrategy;
+use Ergonode\Attribute\Domain\Entity\Attribute\NumericAttribute;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
+use Ergonode\Attribute\Domain\Entity\AbstractAttribute;
 use Symfony\Component\Validator\Constraints\Collection;
-use Ergonode\Attribute\Infrastructure\Provider\Strategy\PriceAttributeValueConstraintStrategy;
+use PHPUnit\Framework\TestCase;
 
 /**
  */
-class PriceAttributeValueConstraintStrategyTest extends TestCase
+class NumericAttributeValueConstraintStrategyTest extends TestCase
 {
     /**
-     * @var PriceAttributeValueConstraintStrategy|MockObject
+     * @var NumericAttributeValueConstraintStrategy|MockObject
      */
-    private PriceAttributeValueConstraintStrategy $strategy;
+    private NumericAttributeValueConstraintStrategy $strategy;
 
     /**
-     * @var PriceAttribute|MockObject
+     * @var NumericAttribute|MockObject
      */
-    private PriceAttribute $attribute;
+    private NumericAttribute $attribute;
 
     /**
      */
     protected function setUp(): void
     {
-        $this->strategy = new PriceAttributeValueConstraintStrategy();
-        $this->attribute = $this->createMock(PriceAttribute::class);
+        $this->strategy = new NumericAttributeValueConstraintStrategy();
+        $this->attribute = $this->createMock(NumericAttribute::class);
     }
 
     /**

--- a/module/attribute/tests/Infrastructure/Provider/Strategy/OptionAttributeValueConstraintStrategyTest.php
+++ b/module/attribute/tests/Infrastructure/Provider/Strategy/OptionAttributeValueConstraintStrategyTest.php
@@ -8,33 +8,37 @@ declare(strict_types = 1);
 
 namespace Ergonode\Attribute\Tests\Infrastructure\Provider\Strategy;
 
-use Ergonode\Attribute\Domain\Entity\AbstractAttribute;
-use Ergonode\Attribute\Domain\Entity\Attribute\PriceAttribute;
-use PHPUnit\Framework\MockObject\MockObject;
+use Ergonode\Attribute\Infrastructure\Provider\Strategy\OptionAttributeValueConstraintStrategy;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Ergonode\Attribute\Domain\Entity\Attribute\PriceAttribute;
+use Ergonode\Attribute\Domain\Entity\AbstractAttribute;
 use Symfony\Component\Validator\Constraints\Collection;
-use Ergonode\Attribute\Infrastructure\Provider\Strategy\PriceAttributeValueConstraintStrategy;
+use Ergonode\Attribute\Domain\Query\OptionQueryInterface;
+use Ergonode\Attribute\Domain\Entity\Attribute\AbstractOptionAttribute;
 
 /**
  */
-class PriceAttributeValueConstraintStrategyTest extends TestCase
+class OptionAttributeValueConstraintStrategyTest extends TestCase
 {
     /**
-     * @var PriceAttributeValueConstraintStrategy|MockObject
+     * @var OptionAttributeValueConstraintStrategy|MockObject
      */
-    private PriceAttributeValueConstraintStrategy $strategy;
+    private $strategy;
 
     /**
      * @var PriceAttribute|MockObject
      */
-    private PriceAttribute $attribute;
+    private $attribute;
 
     /**
      */
     protected function setUp(): void
     {
-        $this->strategy = new PriceAttributeValueConstraintStrategy();
-        $this->attribute = $this->createMock(PriceAttribute::class);
+        $query = $this->createMock(OptionQueryInterface::class);
+        $query->method('getOptions')->willReturn([]);
+        $this->strategy = new OptionAttributeValueConstraintStrategy($query);
+        $this->attribute = $this->createMock(AbstractOptionAttribute::class);
     }
 
     /**

--- a/module/attribute/tests/Infrastructure/Provider/Strategy/TextAttributeValueConstraintStrategyTest.php
+++ b/module/attribute/tests/Infrastructure/Provider/Strategy/TextAttributeValueConstraintStrategyTest.php
@@ -8,33 +8,33 @@ declare(strict_types = 1);
 
 namespace Ergonode\Attribute\Tests\Infrastructure\Provider\Strategy;
 
-use Ergonode\Attribute\Domain\Entity\AbstractAttribute;
-use Ergonode\Attribute\Domain\Entity\Attribute\PriceAttribute;
-use PHPUnit\Framework\MockObject\MockObject;
+use Ergonode\Attribute\Infrastructure\Provider\Strategy\TextAttributeValueConstraintStrategy;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Ergonode\Attribute\Domain\Entity\AbstractAttribute;
 use Symfony\Component\Validator\Constraints\Collection;
-use Ergonode\Attribute\Infrastructure\Provider\Strategy\PriceAttributeValueConstraintStrategy;
+use Ergonode\Attribute\Domain\Entity\Attribute\TextAttribute;
 
 /**
  */
-class PriceAttributeValueConstraintStrategyTest extends TestCase
+class TextAttributeValueConstraintStrategyTest extends TestCase
 {
     /**
-     * @var PriceAttributeValueConstraintStrategy|MockObject
+     * @var TextAttributeValueConstraintStrategy|MockObject
      */
-    private PriceAttributeValueConstraintStrategy $strategy;
+    private TextAttributeValueConstraintStrategy $strategy;
 
     /**
-     * @var PriceAttribute|MockObject
+     * @var TextAttribute|MockObject
      */
-    private PriceAttribute $attribute;
+    private TextAttribute $attribute;
 
     /**
      */
     protected function setUp(): void
     {
-        $this->strategy = new PriceAttributeValueConstraintStrategy();
-        $this->attribute = $this->createMock(PriceAttribute::class);
+        $this->strategy = new TextAttributeValueConstraintStrategy();
+        $this->attribute = $this->createMock(TextAttribute::class);
     }
 
     /**

--- a/module/attribute/tests/Infrastructure/Provider/Strategy/TextareaAttributeValueConstraintStrategyTest.php
+++ b/module/attribute/tests/Infrastructure/Provider/Strategy/TextareaAttributeValueConstraintStrategyTest.php
@@ -8,33 +8,33 @@ declare(strict_types = 1);
 
 namespace Ergonode\Attribute\Tests\Infrastructure\Provider\Strategy;
 
-use Ergonode\Attribute\Domain\Entity\AbstractAttribute;
-use Ergonode\Attribute\Domain\Entity\Attribute\PriceAttribute;
-use PHPUnit\Framework\MockObject\MockObject;
+use Ergonode\Attribute\Infrastructure\Provider\Strategy\TextareaAttributeValueConstraintStrategy;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Ergonode\Attribute\Domain\Entity\Attribute\TextareaAttribute;
+use Ergonode\Attribute\Domain\Entity\AbstractAttribute;
 use Symfony\Component\Validator\Constraints\Collection;
-use Ergonode\Attribute\Infrastructure\Provider\Strategy\PriceAttributeValueConstraintStrategy;
 
 /**
  */
-class PriceAttributeValueConstraintStrategyTest extends TestCase
+class TextareaAttributeValueConstraintStrategyTest extends TestCase
 {
     /**
-     * @var PriceAttributeValueConstraintStrategy|MockObject
+     * @var TextareaAttributeValueConstraintStrategy|MockObject
      */
-    private PriceAttributeValueConstraintStrategy $strategy;
+    private TextareaAttributeValueConstraintStrategy $strategy;
 
     /**
-     * @var PriceAttribute|MockObject
+     * @var TextareaAttribute|MockObject
      */
-    private PriceAttribute $attribute;
+    private TextareaAttribute $attribute;
 
     /**
      */
     protected function setUp(): void
     {
-        $this->strategy = new PriceAttributeValueConstraintStrategy();
-        $this->attribute = $this->createMock(PriceAttribute::class);
+        $this->strategy = new TextareaAttributeValueConstraintStrategy();
+        $this->attribute = $this->createMock(TextareaAttribute::class);
     }
 
     /**

--- a/module/attribute/tests/Infrastructure/Provider/Strategy/UnitAttributeValueConstraintStrategyTest.php
+++ b/module/attribute/tests/Infrastructure/Provider/Strategy/UnitAttributeValueConstraintStrategyTest.php
@@ -8,33 +8,33 @@ declare(strict_types = 1);
 
 namespace Ergonode\Attribute\Tests\Infrastructure\Provider\Strategy;
 
-use Ergonode\Attribute\Domain\Entity\AbstractAttribute;
-use Ergonode\Attribute\Domain\Entity\Attribute\PriceAttribute;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Ergonode\Attribute\Infrastructure\Provider\Strategy\UnitAttributeValueConstraintStrategy;
+use PHPUnit\Framework\MockObject\MockObject;
+use Ergonode\Attribute\Domain\Entity\Attribute\UnitAttribute;
+use Ergonode\Attribute\Domain\Entity\AbstractAttribute;
 use Symfony\Component\Validator\Constraints\Collection;
-use Ergonode\Attribute\Infrastructure\Provider\Strategy\PriceAttributeValueConstraintStrategy;
 
 /**
  */
-class PriceAttributeValueConstraintStrategyTest extends TestCase
+class UnitAttributeValueConstraintStrategyTest extends TestCase
 {
     /**
-     * @var PriceAttributeValueConstraintStrategy|MockObject
+     * @var UnitAttributeValueConstraintStrategy|MockObject
      */
-    private PriceAttributeValueConstraintStrategy $strategy;
+    private UnitAttributeValueConstraintStrategy $strategy;
 
     /**
-     * @var PriceAttribute|MockObject
+     * @var UnitAttribute|MockObject
      */
-    private PriceAttribute $attribute;
+    private UnitAttribute $attribute;
 
     /**
      */
     protected function setUp(): void
     {
-        $this->strategy = new PriceAttributeValueConstraintStrategy();
-        $this->attribute = $this->createMock(PriceAttribute::class);
+        $this->strategy = new UnitAttributeValueConstraintStrategy();
+        $this->attribute = $this->createMock(UnitAttribute::class);
     }
 
     /**


### PR DESCRIPTION
# Description
Fixes a problem with fetching list of options for value validator on edited product for select and multiselect attributes.

## Type of change

Add custom query for fetching list of options ids for given attribute

# How Has This Been Tested?

- [x] Unit Tests

# Checklist:

- [x] I have read the contribution requirements and fulfill them.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes