### PR TITLE
Allow Value module to be used for more then just Categories (fix #1101)

### DIFF
--- a/module/value/composer.json
+++ b/module/value/composer.json
@@ -15,7 +15,6 @@
         "php": "^7.4",
         "doctrine/dbal": "^2.10",
         "ergonode/attribute": "^1.0.0-beta.8",
-        "ergonode/category": "^1.0.0-beta.8",
         "ergonode/core": "^1.0.0-beta.8",
         "ergonode/es": "^1.0.0-beta.8",
         "ergonode/shared-kernel": "^1.0.0-beta.8",

--- a/module/value/src/Domain/Event/ValueAddedEvent.php
+++ b/module/value/src/Domain/Event/ValueAddedEvent.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace Ergonode\Value\Domain\Event;
 
 use Ergonode\Attribute\Domain\ValueObject\AttributeCode;
-use Ergonode\SharedKernel\Domain\Aggregate\CategoryId;
 use Ergonode\SharedKernel\Domain\AggregateEventInterface;
 use Ergonode\SharedKernel\Domain\AggregateId;
 use Ergonode\Value\Domain\ValueObject\ValueInterface;
@@ -19,9 +18,9 @@ use JMS\Serializer\Annotation as JMS;
 class ValueAddedEvent implements AggregateEventInterface
 {
     /**
-     * @JMS\Type(" Ergonode\SharedKernel\Domain\Aggregate\CategoryId")
+     * @JMS\Type("Ergonode\SharedKernel\Domain\AggregateId")
      */
-    private CategoryId $id;
+    private AggregateId $id;
 
     /**
      * @JMS\Type("Ergonode\Attribute\Domain\ValueObject\AttributeCode")
@@ -33,16 +32,13 @@ class ValueAddedEvent implements AggregateEventInterface
      */
     private ValueInterface $value;
 
-    public function __construct(CategoryId $id, AttributeCode $code, ValueInterface $value)
+    public function __construct(AggregateId $id, AttributeCode $code, ValueInterface $value)
     {
         $this->id = $id;
         $this->code = $code;
         $this->value = $value;
     }
 
-    /**
-     * @return AggregateId|CategoryId
-     */
     public function getAggregateId(): AggregateId
     {
         return $this->id;

--- a/module/value/src/Domain/Event/ValueChangedEvent.php
+++ b/module/value/src/Domain/Event/ValueChangedEvent.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace Ergonode\Value\Domain\Event;
 
 use Ergonode\Attribute\Domain\ValueObject\AttributeCode;
-use Ergonode\SharedKernel\Domain\Aggregate\CategoryId;
 use Ergonode\SharedKernel\Domain\AggregateEventInterface;
 use Ergonode\SharedKernel\Domain\AggregateId;
 use Ergonode\Value\Domain\ValueObject\ValueInterface;
@@ -19,9 +18,9 @@ use JMS\Serializer\Annotation as JMS;
 class ValueChangedEvent implements AggregateEventInterface
 {
     /**
-     * @JMS\Type(" Ergonode\SharedKernel\Domain\Aggregate\CategoryId")
+     * @JMS\Type("Ergonode\SharedKernel\Domain\AggregateId")
      */
-    private CategoryId $id;
+    private AggregateId $id;
 
     /**
      * @JMS\Type("Ergonode\Attribute\Domain\ValueObject\AttributeCode")
@@ -33,16 +32,13 @@ class ValueChangedEvent implements AggregateEventInterface
      */
     private ValueInterface $to;
 
-    public function __construct(CategoryId $id, AttributeCode $code, ValueInterface $to)
+    public function __construct(AggregateId $id, AttributeCode $code, ValueInterface $to)
     {
         $this->id = $id;
         $this->code = $code;
         $this->to = $to;
     }
 
-    /**
-     * @return CategoryId|AggregateId
-     */
     public function getAggregateId(): AggregateId
     {
         return $this->id;

--- a/module/value/src/Domain/Event/ValueRemovedEvent.php
+++ b/module/value/src/Domain/Event/ValueRemovedEvent.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace Ergonode\Value\Domain\Event;
 
 use Ergonode\Attribute\Domain\ValueObject\AttributeCode;
-use Ergonode\SharedKernel\Domain\Aggregate\CategoryId;
 use Ergonode\SharedKernel\Domain\AggregateEventInterface;
 use Ergonode\SharedKernel\Domain\AggregateId;
 use Ergonode\Value\Domain\ValueObject\ValueInterface;
@@ -19,9 +18,9 @@ use JMS\Serializer\Annotation as JMS;
 class ValueRemovedEvent implements AggregateEventInterface
 {
     /**
-     * @JMS\Type(" Ergonode\SharedKernel\Domain\Aggregate\CategoryId")
+     * @JMS\Type("Ergonode\SharedKernel\Domain\AggregateId")
      */
-    private CategoryId $id;
+    private AggregateId $id;
 
     /**
      * @JMS\Type("Ergonode\Attribute\Domain\ValueObject\AttributeCode")
@@ -33,16 +32,13 @@ class ValueRemovedEvent implements AggregateEventInterface
      */
     private ValueInterface $old;
 
-    public function __construct(CategoryId $id, AttributeCode $code, ValueInterface $old)
+    public function __construct(AggregateId $id, AttributeCode $code, ValueInterface $old)
     {
         $this->id = $id;
         $this->code = $code;
         $this->old = $old;
     }
 
-    /**
-     * @return CategoryId|AggregateId
-     */
     public function getAggregateId(): AggregateId
     {
         return $this->id;

--- a/module/value/tests/Domain/Event/ValueAddedEventTest.php
+++ b/module/value/tests/Domain/Event/ValueAddedEventTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Ergonode\Value\Tests\Domain\Event;
 
 use Ergonode\Attribute\Domain\ValueObject\AttributeCode;
-use Ergonode\SharedKernel\Domain\Aggregate\CategoryId;
+use Ergonode\SharedKernel\Domain\AggregateId;
 use Ergonode\Value\Domain\Event\ValueAddedEvent;
 use Ergonode\Value\Domain\ValueObject\ValueInterface;
 use PHPUnit\Framework\TestCase;
@@ -19,8 +19,8 @@ class ValueAddedEventTest extends TestCase
 {
     public function testEventCreation(): void
     {
-        /** @var CategoryId $id */
-        $id = $this->createMock(CategoryId::class);
+        /** @var AggregateId $id */
+        $id = $this->createMock(AggregateId::class);
         /** @var AttributeCode $code */
         $code = $this->createMock(AttributeCode::class);
         /** @var ValueInterface $value */

--- a/module/value/tests/Domain/Event/ValueChangedEventTest.php
+++ b/module/value/tests/Domain/Event/ValueChangedEventTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Ergonode\Value\Tests\Domain\Event;
 
 use Ergonode\Attribute\Domain\ValueObject\AttributeCode;
-use Ergonode\SharedKernel\Domain\Aggregate\CategoryId;
+use Ergonode\SharedKernel\Domain\AggregateId;
 use Ergonode\Value\Domain\Event\ValueChangedEvent;
 use Ergonode\Value\Domain\ValueObject\ValueInterface;
 use PHPUnit\Framework\TestCase;
@@ -19,8 +19,8 @@ class ValueChangedEventTest extends TestCase
 {
     public function testEventCreation(): void
     {
-        /** @var CategoryId $id */
-        $id = $this->createMock(CategoryId::class);
+        /** @var AggregateId $id */
+        $id = $this->createMock(AggregateId::class);
         /** @var AttributeCode $code */
         $code = $this->createMock(AttributeCode::class);
         /** @var ValueInterface $to */

--- a/module/value/tests/Domain/Event/ValueRemovedEventTest.php
+++ b/module/value/tests/Domain/Event/ValueRemovedEventTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Ergonode\Value\Tests\Domain\Event;
 
 use Ergonode\Attribute\Domain\ValueObject\AttributeCode;
-use Ergonode\SharedKernel\Domain\Aggregate\CategoryId;
+use Ergonode\SharedKernel\Domain\AggregateId;
 use Ergonode\Value\Domain\Event\ValueRemovedEvent;
 use Ergonode\Value\Domain\ValueObject\ValueInterface;
 use PHPUnit\Framework\TestCase;
@@ -19,8 +19,8 @@ class ValueRemovedEventTest extends TestCase
 {
     public function testEventCreation(): void
     {
-        /** @var CategoryId $id */
-        $id = $this->createMock(CategoryId::class);
+        /** @var AggregateId $id */
+        $id = $this->createMock(AggregateId::class);
         /** @var AttributeCode $code */
         $code = $this->createMock(AttributeCode::class);
         /** @var ValueInterface $value */


### PR DESCRIPTION
# Description
The Value module can't be used for managing attributes of any entity except for categories.

This PR resolves that by replacing the type hint `Ergonode\SharedKernel\Domain\Aggregate\CategoryId` with`Ergonode\SharedKernel\Domain\AggregateId` for
    - `Ergonode\Value\Domain\EventValueAddedEvent::__construct`
    - `Ergonode\Value\Domain\EventValueChangedEvent::__construct`
    - `Ergonode\Value\Domain\EventRemovedChangedEvent::__construct`

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
To expose the issue I've created `App\` classes and a unit test in a dedicated branch: [dankempster/ergonode-backend:expose-value-module-to-categeory-module-coupling](https://github.com/dankempster/ergonode-backend/tree/expose-value-module-to-categeory-module-coupling).
To run that test, pull down that branch within a `ergonode/docker` environment and run `docker-compose exec php ./bin/phpunit tests/`.

As part of this patch, I've updated the existing unit tests for the modified classes.

- [x] Unit Tests
- [ ] Behat Test

# Checklist:
- [x] I have read the contribution requirements and fulfill them.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have ~added~ modified tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
