### PR TITLE
bugfix(exporter-file, importer-ergonode-1) Handle escaping newlines on CSV export/import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 
 ## CHANGELOG FOR 1.0.x
+#### 1.0.2
+- bugfix [#1460](https://github.com/ergonode/backend/issues/1460) handle escaping newlines on CSV export/import (kardi31)
+
 #### 1.0.1
 - refactor [#1438](https://github.com/ergonode/backend/issues/1438) Commands take aggregates objects instead of id object (wfajczyk)
 - bugfix [#1436](https://github.com/ergonode/backend/issues/1436) Incorrect deletion of workflow status (rprzedzik)

--- a/module/exporter-file/src/Infrastructure/Writer/CsvWriter.php
+++ b/module/exporter-file/src/Infrastructure/Writer/CsvWriter.php
@@ -41,7 +41,8 @@ class CsvWriter implements WriterInterface
     {
         $result = [];
         foreach ($data->getLines() as $line) {
-            $result[] = $this->formatLine($line->getValues());
+            $value = str_replace("\n", "\\n", $line->getValues());
+            $result[] = $this->formatLine($value);
         }
 
         return $result;

--- a/module/importer-ergonode-1/src/Infrastructure/Reader/ErgonodeProductReader.php
+++ b/module/importer-ergonode-1/src/Infrastructure/Reader/ErgonodeProductReader.php
@@ -46,7 +46,8 @@ class ErgonodeProductReader extends AbstractErgonodeReader
             }
 
             foreach ($attributes as $attribute) {
-                $item->addAttribute($attribute, $record['_language'], $record[$attribute]);
+                $value = str_replace("\\n", "\n", $record[$attribute]);
+                $item->addAttribute($attribute, $record['_language'], $value);
             }
 
             foreach ($record as $key => $value) {


### PR DESCRIPTION
As requested in https://github.com/ergonode/backend/pull/1461#pullrequestreview-672778696