### PR TITLE
refactor(attribute) make AttributeId::fromKey method deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## CHANGELOG FOR 1.3.x
+#### 1.3.0
+- refactor [#1736](https://github.com/ergonode/backend/issues/1736) Make AttributeId::fromKey method deprecated (rprzedzik)
 ## CHANGELOG FOR 1.2.x
 #### 1.2.0
 - performance [#1729](https://github.com/ergonode/backend/issues/1729) Serialization performance upgrade with Closure API (piotrkreft)

--- a/UPGRADE-1.3.md
+++ b/UPGRADE-1.3.md
@@ -1,0 +1,11 @@
+UPGRADE FROM 1.2 to 1.3
+
+Attribute:
+* Method `AttributeId:fromKey` become deprecated, will be removed in future version
+* The signature of constructor `ProductReadInheritedValuesByLanguageAction` has changed
+* The signature of constructor `DbalCategoryCreatedEventProjector` has changed
+* The signature of constructor `AbstractProductProjector` has changed
+* The signature of constructor `DbalProductValueAddedEventProjector` has changed
+* The signature of constructor `DbalValueAddedEventProjector` has changed
+* The signature of constructor `DbalValueChangedEventProjector` has changed
+* The signature of constructor `ProductWorkflowQuery` has changed

--- a/UPGRADE-1.3.md
+++ b/UPGRADE-1.3.md
@@ -4,8 +4,10 @@ Attribute:
 * Method `AttributeId:fromKey` become deprecated, will be removed in future version
 * The signature of constructor `ProductReadInheritedValuesByLanguageAction` has changed
 * The signature of constructor `DbalCategoryCreatedEventProjector` has changed
-* The signature of constructor `AbstractProductProjector` has changed
-* The signature of constructor `DbalProductValueAddedEventProjector` has changed
 * The signature of constructor `DbalValueAddedEventProjector` has changed
-* The signature of constructor `DbalValueChangedEventProjector` has changed
+* The signature of constructor `DbalValueChangedEventProjector` has changed 
+* The signature of constructor `DbalValueRemovedEventProjector` has changed
+* The signature of constructor `DbalProductValueAddedEventProjector` has changed
+* The signature of constructor `DbalProductValueChangedEventProjector` has changed
+* The signature of constructor `DbalProductValueRemovedEventProjector` has changed
 * The signature of constructor `ProductWorkflowQuery` has changed

--- a/module/attribute/src/Domain/Command/Attribute/AbstractCreateAttributeCommand.php
+++ b/module/attribute/src/Domain/Command/Attribute/AbstractCreateAttributeCommand.php
@@ -47,7 +47,7 @@ abstract class AbstractCreateAttributeCommand implements CreateAttributeCommandI
         array $groups = []
     ) {
         Assert::allIsInstanceOf($groups, AttributeGroupId::class);
-        $this->attributeId = AttributeId::fromKey($code->getValue());
+        $this->attributeId = AttributeId::generate();
         $this->code = $code;
         $this->label = $label;
         $this->hint = $hint;

--- a/module/attribute/tests/Domain/Command/Attribute/Create/CreateDateAttributeCommandTest.php
+++ b/module/attribute/tests/Domain/Command/Attribute/Create/CreateDateAttributeCommandTest.php
@@ -13,7 +13,6 @@ use Ergonode\Attribute\Domain\ValueObject\AttributeCode;
 use Ergonode\Attribute\Domain\ValueObject\AttributeScope;
 use Ergonode\Attribute\Domain\ValueObject\DateFormat;
 use Ergonode\Core\Domain\ValueObject\TranslatableString;
-use Ergonode\SharedKernel\Domain\Aggregate\AttributeId;
 use PHPUnit\Framework\TestCase;
 
 class CreateDateAttributeCommandTest extends TestCase
@@ -45,7 +44,6 @@ class CreateDateAttributeCommandTest extends TestCase
         );
 
         $this->assertSame($attributeCode, $command->getCode());
-        $this->assertEquals(AttributeId::fromKey($attributeCode->getValue()), $command->getId());
         $this->assertSame($label, $command->getLabel());
         $this->assertSame($hint, $command->getHint());
         $this->assertSame($placeholder, $command->getPlaceholder());

--- a/module/attribute/tests/Domain/Command/Attribute/Create/CreatePriceAttributeCommandTest.php
+++ b/module/attribute/tests/Domain/Command/Attribute/Create/CreatePriceAttributeCommandTest.php
@@ -12,7 +12,6 @@ use Ergonode\Attribute\Domain\Command\Attribute\Create\CreatePriceAttributeComma
 use Ergonode\Attribute\Domain\ValueObject\AttributeCode;
 use Ergonode\Attribute\Domain\ValueObject\AttributeScope;
 use Ergonode\Core\Domain\ValueObject\TranslatableString;
-use Ergonode\SharedKernel\Domain\Aggregate\AttributeId;
 use Money\Currency;
 use PHPUnit\Framework\TestCase;
 
@@ -45,7 +44,6 @@ class CreatePriceAttributeCommandTest extends TestCase
         );
 
         $this->assertSame($attributeCode, $command->getCode());
-        $this->assertEquals(AttributeId::fromKey($attributeCode->getValue()), $command->getId());
         $this->assertSame($label, $command->getLabel());
         $this->assertSame($hint, $command->getHint());
         $this->assertSame($placeholder, $command->getPlaceholder());

--- a/module/attribute/tests/Domain/Command/Attribute/Create/CreateUnitAttributeCommandTest.php
+++ b/module/attribute/tests/Domain/Command/Attribute/Create/CreateUnitAttributeCommandTest.php
@@ -12,7 +12,6 @@ use Ergonode\Attribute\Domain\Command\Attribute\Create\CreateUnitAttributeComman
 use Ergonode\Attribute\Domain\ValueObject\AttributeCode;
 use Ergonode\Attribute\Domain\ValueObject\AttributeScope;
 use Ergonode\Core\Domain\ValueObject\TranslatableString;
-use Ergonode\SharedKernel\Domain\Aggregate\AttributeId;
 use Ergonode\SharedKernel\Domain\Aggregate\UnitId;
 use PHPUnit\Framework\TestCase;
 
@@ -45,7 +44,6 @@ class CreateUnitAttributeCommandTest extends TestCase
         );
 
         $this->assertSame($attributeCode, $command->getCode());
-        $this->assertEquals(AttributeId::fromKey($attributeCode->getValue()), $command->getId());
         $this->assertSame($label, $command->getLabel());
         $this->assertSame($hint, $command->getHint());
         $this->assertSame($placeholder, $command->getPlaceholder());

--- a/module/category/src/Domain/Entity/Attribute/CategorySystemAttribute.php
+++ b/module/category/src/Domain/Entity/Attribute/CategorySystemAttribute.php
@@ -33,7 +33,7 @@ class CategorySystemAttribute extends AbstractOptionAttribute
         TranslatableString $placeholder
     ) {
         $code = new AttributeCode(self::CODE);
-        $id = AttributeId::fromKey($code->getValue());
+        $id = AttributeId::generate();
         $scope = new AttributeScope(AttributeScope::GLOBAL);
 
         parent::__construct($id, $code, $label, $hint, $placeholder, $scope);

--- a/module/category/src/Infrastructure/Persistence/Projector/Category/DbalCategoryCreatedEventProjector.php
+++ b/module/category/src/Infrastructure/Persistence/Projector/Category/DbalCategoryCreatedEventProjector.php
@@ -15,6 +15,8 @@ use Ergonode\Category\Domain\Event\CategoryCreatedEvent;
 use Ergonode\SharedKernel\Application\Serializer\SerializerInterface;
 use Ergonode\SharedKernel\Domain\Aggregate\AttributeId;
 use Ramsey\Uuid\Uuid;
+use Ergonode\Attribute\Domain\Query\AttributeQueryInterface;
+use Webmozart\Assert\Assert;
 
 class DbalCategoryCreatedEventProjector
 {
@@ -27,12 +29,14 @@ class DbalCategoryCreatedEventProjector
 
     private SerializerInterface $serializer;
 
-    public function __construct(Connection $connection, SerializerInterface $serializer)
+    private AttributeQueryInterface $query;
+
+    public function __construct(Connection $connection, SerializerInterface $serializer, AttributeQueryInterface $query)
     {
         $this->connection = $connection;
         $this->serializer = $serializer;
+        $this->query = $query;
     }
-
 
     /**
      * {@inheritDoc}
@@ -53,7 +57,8 @@ class DbalCategoryCreatedEventProjector
             );
 
             foreach ($event->getAttributes() as $code => $value) {
-                $attributeId = AttributeId::fromKey((new AttributeCode($code))->getValue());
+                $attributeId = $this->query->findAttributeIdByCode(new AttributeCode($code));
+                Assert::isInstanceOf($attributeId, AttributeId::class);
                 $type = get_class($value);
                 $value = $this->serializer->serialize($value);
 

--- a/module/completeness/migrations/Version20210818160000.php
+++ b/module/completeness/migrations/Version20210818160000.php
@@ -23,7 +23,9 @@ class Version20210818160000 extends AbstractErgonodeMigration
     public function up(Schema $schema): void
     {
         $label = Uuid::uuid4()->toString();
-        $attributeId = AttributeId::fromKey(CompletenessSystemAttribute::CODE);
+        $uuid = Uuid::uuid5('eb5fa5eb-ecda-4ff6-ac91-9ac817062635', CompletenessSystemAttribute::CODE)->toString();
+        $attributeId = new AttributeId($uuid);
+
         $eventId = $this->connection->executeQuery(
             'SELECT id FROM event_store_event WHERE event_class = :class',
             [

--- a/module/completeness/src/Domain/Entity/Attribute/CompletenessSystemAttribute.php
+++ b/module/completeness/src/Domain/Entity/Attribute/CompletenessSystemAttribute.php
@@ -30,7 +30,7 @@ class CompletenessSystemAttribute extends AbstractNumericAttribute
         TranslatableString $placeholder
     ) {
         $code = new AttributeCode(self::CODE);
-        $id = AttributeId::fromKey($code->getValue());
+        $id = AttributeId::generate();
         $scope = new AttributeScope(AttributeScope::LOCAL);
 
         parent::__construct($id, $code, $label, $hint, $placeholder, $scope);

--- a/module/designer/src/Domain/Entity/Attribute/DefaultImageSystemAttribute.php
+++ b/module/designer/src/Domain/Entity/Attribute/DefaultImageSystemAttribute.php
@@ -30,7 +30,7 @@ class DefaultImageSystemAttribute extends AbstractImageAttribute
         TranslatableString $placeholder
     ) {
         $code = new AttributeCode(self::CODE);
-        $id = AttributeId::fromKey($code->getValue());
+        $id = AttributeId::generate();
         $scope = new AttributeScope(AttributeScope::LOCAL);
 
         parent::__construct($id, $code, $label, $hint, $placeholder, $scope);

--- a/module/designer/src/Domain/Entity/Attribute/DefaultLabelSystemAttribute.php
+++ b/module/designer/src/Domain/Entity/Attribute/DefaultLabelSystemAttribute.php
@@ -30,7 +30,7 @@ class DefaultLabelSystemAttribute extends AbstractTextAttribute
         TranslatableString $placeholder
     ) {
         $code = new AttributeCode(self::CODE);
-        $id = AttributeId::fromKey($code->getValue());
+        $id = AttributeId::generate();
         $scope = new AttributeScope(AttributeScope::LOCAL);
 
         parent::__construct($id, $code, $label, $hint, $placeholder, $scope);

--- a/module/designer/src/Domain/Entity/Attribute/TemplateSystemAttribute.php
+++ b/module/designer/src/Domain/Entity/Attribute/TemplateSystemAttribute.php
@@ -28,7 +28,7 @@ class TemplateSystemAttribute extends AbstractOptionAttribute
         TranslatableString $placeholder
     ) {
         $code = new AttributeCode(self::CODE);
-        $id = AttributeId::fromKey($code->getValue());
+        $id = AttributeId::generate();
         $scope = new AttributeScope(AttributeScope::GLOBAL);
 
         parent::__construct($id, $code, $label, $hint, $placeholder, $scope);

--- a/module/fixture/src/Infrastructure/Faker/AttributeIdFaker.php
+++ b/module/fixture/src/Infrastructure/Faker/AttributeIdFaker.php
@@ -10,19 +10,20 @@ declare(strict_types=1);
 namespace Ergonode\Fixture\Infrastructure\Faker;
 
 use Ergonode\SharedKernel\Domain\Aggregate\AttributeId;
-use Ergonode\Attribute\Domain\ValueObject\AttributeCode;
 use Faker\Provider\Base as BaseProvider;
+use Ramsey\Uuid\Uuid;
 
 class AttributeIdFaker extends BaseProvider
 {
+    private const NAMESPACE = 'eb5fa5eb-ecda-4ff6-ac91-9ac817062635';
+
     /**
      * @throws \Exception
      */
     public function attributeId(?string $code = null): AttributeId
     {
-
         if ($code) {
-            return AttributeId::fromKey((new AttributeCode($code))->getValue());
+            return new AttributeId(Uuid::uuid5(self::NAMESPACE, $code)->toString());
         }
 
         return AttributeId::generate();

--- a/module/grid/src/Column/LabelColumn.php
+++ b/module/grid/src/Column/LabelColumn.php
@@ -9,30 +9,10 @@ declare(strict_types=1);
 
 namespace Ergonode\Grid\Column;
 
-use Ergonode\SharedKernel\Domain\Aggregate\AttributeId;
-use Ergonode\Attribute\Domain\ValueObject\AttributeCode;
-use Ergonode\Grid\FilterInterface;
-
 class LabelColumn extends AbstractColumn
 {
     public const TYPE = 'LABEL';
 
-    /**
-     * @throws \Exception
-     */
-    public function __construct(
-        string $field,
-        ?string $label = null,
-        FilterInterface $filter = null
-    ) {
-        parent::__construct($field, $label, $filter);
-
-        $this->setExtension('element_id', AttributeId::fromKey((new AttributeCode($field))->getValue())->getValue());
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function getType(): string
     {
         return self::TYPE;

--- a/module/importer/src/Infrastructure/Action/DateAttributeImportAction.php
+++ b/module/importer/src/Infrastructure/Action/DateAttributeImportAction.php
@@ -32,7 +32,7 @@ class DateAttributeImportAction extends AbstractAttributeImportAction
         $attribute = $this->findAttribute(new AttributeCode($command->getCode()));
         if (!$attribute) {
             $attribute = new DateAttribute(
-                AttributeId::fromKey($command->getCode()),
+                AttributeId::generate(),
                 new AttributeCode($command->getCode()),
                 new TranslatableString($command->getLabel()),
                 new TranslatableString($command->getHint()),

--- a/module/importer/src/Infrastructure/Action/FileAttributeImportAction.php
+++ b/module/importer/src/Infrastructure/Action/FileAttributeImportAction.php
@@ -28,7 +28,7 @@ class FileAttributeImportAction extends AbstractAttributeImportAction
         $attribute = $this->findAttribute(new AttributeCode($command->getCode()));
         if (!$attribute) {
             $attribute = new FileAttribute(
-                AttributeId::fromKey($command->getCode()),
+                AttributeId::generate(),
                 new AttributeCode($command->getCode()),
                 new TranslatableString($command->getLabel()),
                 new TranslatableString($command->getHint()),

--- a/module/importer/src/Infrastructure/Action/GalleryAttributeImportAction.php
+++ b/module/importer/src/Infrastructure/Action/GalleryAttributeImportAction.php
@@ -28,7 +28,7 @@ class GalleryAttributeImportAction extends AbstractAttributeImportAction
         $attribute = $this->findAttribute(new AttributeCode($command->getCode()));
         if (!$attribute) {
             $attribute = new GalleryAttribute(
-                AttributeId::fromKey($command->getCode()),
+                AttributeId::generate(),
                 new AttributeCode($command->getCode()),
                 new TranslatableString($command->getLabel()),
                 new TranslatableString($command->getHint()),

--- a/module/importer/src/Infrastructure/Action/ImageAttributeImportAction.php
+++ b/module/importer/src/Infrastructure/Action/ImageAttributeImportAction.php
@@ -28,7 +28,7 @@ class ImageAttributeImportAction extends AbstractAttributeImportAction
         $attribute = $this->findAttribute(new AttributeCode($command->getCode()));
         if (!$attribute) {
             $attribute = new ImageAttribute(
-                AttributeId::fromKey($command->getCode()),
+                AttributeId::generate(),
                 new AttributeCode($command->getCode()),
                 new TranslatableString($command->getLabel()),
                 new TranslatableString($command->getHint()),

--- a/module/importer/src/Infrastructure/Action/MultiSelectAttributeImportAction.php
+++ b/module/importer/src/Infrastructure/Action/MultiSelectAttributeImportAction.php
@@ -28,7 +28,7 @@ class MultiSelectAttributeImportAction extends AbstractAttributeImportAction
         $attribute = $this->findAttribute(new AttributeCode($command->getCode()));
         if (!$attribute) {
             $attribute = new MultiSelectAttribute(
-                AttributeId::fromKey($command->getCode()),
+                AttributeId::generate(),
                 new AttributeCode($command->getCode()),
                 new TranslatableString($command->getLabel()),
                 new TranslatableString($command->getHint()),

--- a/module/importer/src/Infrastructure/Action/NumericAttributeImportAction.php
+++ b/module/importer/src/Infrastructure/Action/NumericAttributeImportAction.php
@@ -28,7 +28,7 @@ class NumericAttributeImportAction extends AbstractAttributeImportAction
         $attribute = $this->findAttribute(new AttributeCode($command->getCode()));
         if (!$attribute) {
             $attribute = new NumericAttribute(
-                AttributeId::fromKey($command->getCode()),
+                AttributeId::generate(),
                 new AttributeCode($command->getCode()),
                 new TranslatableString($command->getLabel()),
                 new TranslatableString($command->getHint()),

--- a/module/importer/src/Infrastructure/Action/PriceAttributeImportAction.php
+++ b/module/importer/src/Infrastructure/Action/PriceAttributeImportAction.php
@@ -32,7 +32,7 @@ class PriceAttributeImportAction extends AbstractAttributeImportAction
         $attribute = $this->findAttribute(new AttributeCode($command->getCode()));
         if (!$attribute) {
             $attribute = new PriceAttribute(
-                AttributeId::fromKey($command->getCode()),
+                AttributeId::generate(),
                 new AttributeCode($command->getCode()),
                 new TranslatableString($command->getLabel()),
                 new TranslatableString($command->getHint()),

--- a/module/importer/src/Infrastructure/Action/ProductRelationAttributeImportAction.php
+++ b/module/importer/src/Infrastructure/Action/ProductRelationAttributeImportAction.php
@@ -29,7 +29,7 @@ class ProductRelationAttributeImportAction extends AbstractAttributeImportAction
 
         if (!$attribute) {
             $attribute = new ProductRelationAttribute(
-                AttributeId::fromKey($command->getCode()),
+                AttributeId::generate(),
                 new AttributeCode($command->getCode()),
                 new TranslatableString($command->getLabel()),
                 new TranslatableString($command->getHint()),

--- a/module/importer/src/Infrastructure/Action/SelectAttributeImportAction.php
+++ b/module/importer/src/Infrastructure/Action/SelectAttributeImportAction.php
@@ -29,7 +29,7 @@ class SelectAttributeImportAction extends AbstractAttributeImportAction
         $attribute = $this->findAttribute(new AttributeCode($command->getCode()));
         if (!$attribute) {
             $attribute = new SelectAttribute(
-                AttributeId::fromKey($command->getCode()),
+                AttributeId::generate(),
                 new AttributeCode($command->getCode()),
                 new TranslatableString($command->getLabel()),
                 new TranslatableString($command->getHint()),

--- a/module/importer/src/Infrastructure/Action/TextAttributeImportAction.php
+++ b/module/importer/src/Infrastructure/Action/TextAttributeImportAction.php
@@ -29,7 +29,7 @@ class TextAttributeImportAction extends AbstractAttributeImportAction
 
         if (!$attribute) {
             $attribute = new TextAttribute(
-                AttributeId::fromKey($command->getCode()),
+                AttributeId::generate(),
                 new AttributeCode($command->getCode()),
                 new TranslatableString($command->getLabel()),
                 new TranslatableString($command->getHint()),

--- a/module/importer/src/Infrastructure/Action/TextareaAttributeImportAction.php
+++ b/module/importer/src/Infrastructure/Action/TextareaAttributeImportAction.php
@@ -32,7 +32,7 @@ class TextareaAttributeImportAction extends AbstractAttributeImportAction
 
         if (!$attribute) {
             $attribute = new TextareaAttribute(
-                AttributeId::fromKey($command->getCode()),
+                AttributeId::generate(),
                 new AttributeCode($command->getCode()),
                 new TranslatableString($command->getLabel()),
                 new TranslatableString($command->getHint()),

--- a/module/importer/src/Infrastructure/Action/UnitAttributeImportAction.php
+++ b/module/importer/src/Infrastructure/Action/UnitAttributeImportAction.php
@@ -56,7 +56,7 @@ class UnitAttributeImportAction extends AbstractAttributeImportAction
         $attribute = $this->findAttribute(new AttributeCode($command->getCode()));
         if (!$attribute) {
             $attribute = new UnitAttribute(
-                AttributeId::fromKey($command->getCode()),
+                AttributeId::generate(),
                 new AttributeCode($command->getCode()),
                 new TranslatableString($command->getLabel()),
                 new TranslatableString($command->getHint()),

--- a/module/product-collection/src/Domain/Entity/Attribute/ProductCollectionSystemAttribute.php
+++ b/module/product-collection/src/Domain/Entity/Attribute/ProductCollectionSystemAttribute.php
@@ -34,7 +34,7 @@ class ProductCollectionSystemAttribute extends AbstractOptionAttribute
         TranslatableString $placeholder
     ) {
         $code = new AttributeCode(self::CODE);
-        $id = AttributeId::fromKey($code->getValue());
+        $id = AttributeId::generate();
         $scope = new AttributeScope(AttributeScope::GLOBAL);
 
         parent::__construct($id, $code, $label, $hint, $placeholder, $scope);

--- a/module/product/src/Domain/Entity/Attribute/CreatedAtSystemAttribute.php
+++ b/module/product/src/Domain/Entity/Attribute/CreatedAtSystemAttribute.php
@@ -29,7 +29,7 @@ class CreatedAtSystemAttribute extends AbstractDateAttribute
         TranslatableString $placeholder
     ) {
         $code = new AttributeCode(self::CODE);
-        $id = AttributeId::fromKey($code->getValue());
+        $id = AttributeId::generate();
         $format = new DateFormat(DateFormat::YYYY_MM_DD);
         $scope = new AttributeScope(AttributeScope::GLOBAL);
 

--- a/module/product/src/Domain/Entity/Attribute/CreatedBySystemAttribute.php
+++ b/module/product/src/Domain/Entity/Attribute/CreatedBySystemAttribute.php
@@ -28,7 +28,7 @@ class CreatedBySystemAttribute extends AbstractTextAttribute
         TranslatableString $placeholder
     ) {
         $code = new AttributeCode(self::CODE);
-        $id = AttributeId::fromKey($code->getValue());
+        $id = AttributeId::generate();
         $scope = new AttributeScope(AttributeScope::GLOBAL);
 
         parent::__construct($id, $code, $label, $hint, $placeholder, $scope);

--- a/module/product/src/Domain/Entity/Attribute/EditedAtSystemAttribute.php
+++ b/module/product/src/Domain/Entity/Attribute/EditedAtSystemAttribute.php
@@ -29,7 +29,7 @@ class EditedAtSystemAttribute extends AbstractDateAttribute
         TranslatableString $placeholder
     ) {
         $code = new AttributeCode(self::CODE);
-        $id = AttributeId::fromKey($code->getValue());
+        $id = AttributeId::generate();
         $format = new DateFormat(DateFormat::YYYY_MM_DD);
         $scope = new AttributeScope(AttributeScope::GLOBAL);
 

--- a/module/product/src/Domain/Entity/Attribute/EditedBySystemAttribute.php
+++ b/module/product/src/Domain/Entity/Attribute/EditedBySystemAttribute.php
@@ -28,7 +28,7 @@ class EditedBySystemAttribute extends AbstractTextAttribute
         TranslatableString $placeholder
     ) {
         $code = new AttributeCode(self::CODE);
-        $id = AttributeId::fromKey($code->getValue());
+        $id = AttributeId::generate();
         $scope = new AttributeScope(AttributeScope::GLOBAL);
 
         parent::__construct($id, $code, $label, $hint, $placeholder, $scope);

--- a/module/product/src/Domain/Entity/Attribute/ProductTypeSystemAttribute.php
+++ b/module/product/src/Domain/Entity/Attribute/ProductTypeSystemAttribute.php
@@ -29,7 +29,7 @@ class ProductTypeSystemAttribute extends AbstractTextAttribute
     ) {
         $scope = new AttributeScope(AttributeScope::GLOBAL);
         $code = new AttributeCode(self::CODE);
-        $id = AttributeId::fromKey($code->getValue());
+        $id = AttributeId::generate();
 
         parent::__construct($id, $code, $label, $hint, $placeholder, $scope);
     }

--- a/module/product/src/Infrastructure/Persistence/Projector/AbstractProductProjector.php
+++ b/module/product/src/Infrastructure/Persistence/Projector/AbstractProductProjector.php
@@ -10,7 +10,6 @@ namespace Ergonode\Product\Infrastructure\Persistence\Projector;
 
 use Doctrine\DBAL\Connection;
 use Ergonode\SharedKernel\Domain\AggregateId;
-use Ergonode\Attribute\Domain\Query\AttributeQueryInterface;
 
 abstract class AbstractProductProjector
 {
@@ -18,12 +17,9 @@ abstract class AbstractProductProjector
 
     protected Connection $connection;
 
-    protected AttributeQueryInterface $attributeQuery;
-
-    public function __construct(Connection $connection, AttributeQueryInterface $attributeQuery)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->attributeQuery = $attributeQuery;
     }
 
     protected function updateAudit(AggregateId $id): void

--- a/module/product/src/Infrastructure/Persistence/Projector/AbstractProductProjector.php
+++ b/module/product/src/Infrastructure/Persistence/Projector/AbstractProductProjector.php
@@ -10,6 +10,7 @@ namespace Ergonode\Product\Infrastructure\Persistence\Projector;
 
 use Doctrine\DBAL\Connection;
 use Ergonode\SharedKernel\Domain\AggregateId;
+use Ergonode\Attribute\Domain\Query\AttributeQueryInterface;
 
 abstract class AbstractProductProjector
 {
@@ -17,9 +18,12 @@ abstract class AbstractProductProjector
 
     protected Connection $connection;
 
-    public function __construct(Connection $connection)
+    protected AttributeQueryInterface $attributeQuery;
+
+    public function __construct(Connection $connection, AttributeQueryInterface $attributeQuery)
     {
         $this->connection = $connection;
+        $this->attributeQuery = $attributeQuery;
     }
 
     protected function updateAudit(AggregateId $id): void

--- a/module/product/src/Infrastructure/Persistence/Projector/DbalProductValueAddedEventProjector.php
+++ b/module/product/src/Infrastructure/Persistence/Projector/DbalProductValueAddedEventProjector.php
@@ -13,9 +13,20 @@ use Doctrine\DBAL\DBALException;
 use Ergonode\Product\Domain\Event\ProductValueAddedEvent;
 use Ergonode\Workflow\Domain\Entity\Attribute\StatusSystemAttribute;
 use Webmozart\Assert\Assert;
+use Ergonode\Attribute\Domain\Query\AttributeQueryInterface;
+use Doctrine\DBAL\Connection;
 
 class DbalProductValueAddedEventProjector extends AbstractProductValueProjector
 {
+    private AttributeQueryInterface $attributeQuery;
+
+    public function __construct(Connection $connection, AttributeQueryInterface $attributeQuery)
+    {
+        parent::__construct($connection);
+
+        $this->attributeQuery = $attributeQuery;
+    }
+
     /**
      * @throws DBALException
      */

--- a/module/product/src/Infrastructure/Persistence/Projector/DbalProductValueAddedEventProjector.php
+++ b/module/product/src/Infrastructure/Persistence/Projector/DbalProductValueAddedEventProjector.php
@@ -11,8 +11,8 @@ namespace Ergonode\Product\Infrastructure\Persistence\Projector;
 
 use Doctrine\DBAL\DBALException;
 use Ergonode\Product\Domain\Event\ProductValueAddedEvent;
-use Ergonode\SharedKernel\Domain\Aggregate\AttributeId;
 use Ergonode\Workflow\Domain\Entity\Attribute\StatusSystemAttribute;
+use Webmozart\Assert\Assert;
 
 class DbalProductValueAddedEventProjector extends AbstractProductValueProjector
 {
@@ -21,12 +21,13 @@ class DbalProductValueAddedEventProjector extends AbstractProductValueProjector
      */
     public function __invoke(ProductValueAddedEvent $event): void
     {
-        $productId = $event->getAggregateId()->getValue();
-        $code = $event->getAttributeCode()->getValue();
+        $productId = $event->getAggregateId();
+        $code = $event->getAttributeCode();
 
-        $attributeId = AttributeId::fromKey($event->getAttributeCode()->getValue())->getValue();
-        if (StatusSystemAttribute::CODE !== $code) {
-            $this->insertValue($productId, $attributeId, $event->getValue());
+        $attributeId = $this->attributeQuery->findAttributeIdByCode($code);
+        Assert::notNull($attributeId);
+        if (StatusSystemAttribute::CODE !== $code->getValue()) {
+            $this->insertValue($productId->getValue(), $attributeId->getValue(), $event->getValue());
         }
         $this->updateAudit($event->getAggregateId());
     }

--- a/module/product/src/Infrastructure/Persistence/Projector/DbalProductValueChangedEventProjector.php
+++ b/module/product/src/Infrastructure/Persistence/Projector/DbalProductValueChangedEventProjector.php
@@ -11,7 +11,7 @@ namespace Ergonode\Product\Infrastructure\Persistence\Projector;
 
 use Doctrine\DBAL\DBALException;
 use Ergonode\Product\Domain\Event\ProductValueChangedEvent;
-use Ergonode\SharedKernel\Domain\Aggregate\AttributeId;
+use Webmozart\Assert\Assert;
 
 class DbalProductValueChangedEventProjector extends AbstractProductValueProjector
 {
@@ -21,10 +21,11 @@ class DbalProductValueChangedEventProjector extends AbstractProductValueProjecto
     public function __invoke(ProductValueChangedEvent $event): void
     {
         $productId = $event->getAggregateId()->getValue();
-        $attributeId = AttributeId::fromKey($event->getAttributeCode()->getValue())->getValue();
+        $attributeId = $this->attributeQuery->findAttributeIdByCode($event->getAttributeCode());
+        Assert::notNull($attributeId);
 
-        $this->delete($productId, $attributeId);
-        $this->insertValue($productId, $attributeId, $event->getTo());
+        $this->delete($productId, $attributeId->getValue());
+        $this->insertValue($productId, $attributeId->getValue(), $event->getTo());
         $this->updateAudit($event->getAggregateId());
     }
 }

--- a/module/product/src/Infrastructure/Persistence/Projector/DbalProductValueChangedEventProjector.php
+++ b/module/product/src/Infrastructure/Persistence/Projector/DbalProductValueChangedEventProjector.php
@@ -12,9 +12,20 @@ namespace Ergonode\Product\Infrastructure\Persistence\Projector;
 use Doctrine\DBAL\DBALException;
 use Ergonode\Product\Domain\Event\ProductValueChangedEvent;
 use Webmozart\Assert\Assert;
+use Ergonode\Attribute\Domain\Query\AttributeQueryInterface;
+use Doctrine\DBAL\Connection;
 
 class DbalProductValueChangedEventProjector extends AbstractProductValueProjector
 {
+    private AttributeQueryInterface $attributeQuery;
+
+    public function __construct(Connection $connection, AttributeQueryInterface $attributeQuery)
+    {
+        parent::__construct($connection);
+
+        $this->attributeQuery = $attributeQuery;
+    }
+
     /**
      * @throws DBALException
      */

--- a/module/product/src/Infrastructure/Persistence/Projector/DbalProductValueRemovedEventProjector.php
+++ b/module/product/src/Infrastructure/Persistence/Projector/DbalProductValueRemovedEventProjector.php
@@ -12,9 +12,20 @@ namespace Ergonode\Product\Infrastructure\Persistence\Projector;
 use Doctrine\DBAL\DBALException;
 use Ergonode\Product\Domain\Event\ProductValueRemovedEvent;
 use Webmozart\Assert\Assert;
+use Ergonode\Attribute\Domain\Query\AttributeQueryInterface;
+use Doctrine\DBAL\Connection;
 
 class DbalProductValueRemovedEventProjector extends AbstractProductValueProjector
 {
+    private AttributeQueryInterface $attributeQuery;
+
+    public function __construct(Connection $connection, AttributeQueryInterface $attributeQuery)
+    {
+        parent::__construct($connection);
+
+        $this->attributeQuery = $attributeQuery;
+    }
+
     /**
      * @throws DBALException
      */

--- a/module/product/src/Infrastructure/Persistence/Projector/DbalProductValueRemovedEventProjector.php
+++ b/module/product/src/Infrastructure/Persistence/Projector/DbalProductValueRemovedEventProjector.php
@@ -11,7 +11,7 @@ namespace Ergonode\Product\Infrastructure\Persistence\Projector;
 
 use Doctrine\DBAL\DBALException;
 use Ergonode\Product\Domain\Event\ProductValueRemovedEvent;
-use Ergonode\SharedKernel\Domain\Aggregate\AttributeId;
+use Webmozart\Assert\Assert;
 
 class DbalProductValueRemovedEventProjector extends AbstractProductValueProjector
 {
@@ -21,9 +21,10 @@ class DbalProductValueRemovedEventProjector extends AbstractProductValueProjecto
     public function __invoke(ProductValueRemovedEvent $event): void
     {
         $productId = $event->getAggregateId()->getValue();
-        $attributeId = AttributeId::fromKey($event->getAttributeCode()->getValue())->getValue();
+        $attributeId = $this->attributeQuery->findAttributeIdByCode($event->getAttributeCode());
+        Assert::notNull($attributeId);
 
-        $this->delete($productId, $attributeId);
+        $this->delete($productId, $attributeId->getValue());
         $this->updateAudit($event->getAggregateId());
     }
 }

--- a/module/shared-kernel/src/Domain/Aggregate/AttributeId.php
+++ b/module/shared-kernel/src/Domain/Aggregate/AttributeId.php
@@ -14,8 +14,16 @@ class AttributeId extends AggregateId
 {
     public const NAMESPACE = 'eb5fa5eb-ecda-4ff6-ac91-9ac817062635';
 
+    /**
+     * @deprecated
+     */
     public static function fromKey(string $value): AttributeId
     {
+        @trigger_error(
+            'Ergonode\SharedKernel\Domain\Aggregate::fromKey is deprecated and will be removed in 2.0.',
+            \E_USER_DEPRECATED,
+        );
+
         return new static(self::generateIdentifier(self::NAMESPACE, $value)->getValue());
     }
 }

--- a/module/value/src/Infrastructure/Persistence/Projector/DbalValueChangedEventProjector.php
+++ b/module/value/src/Infrastructure/Persistence/Projector/DbalValueChangedEventProjector.php
@@ -11,9 +11,10 @@ namespace Ergonode\Value\Infrastructure\Persistence\Projector;
 
 use Doctrine\DBAL\Connection;
 use Ergonode\SharedKernel\Application\Serializer\SerializerInterface;
-use Ergonode\SharedKernel\Domain\Aggregate\AttributeId;
 use Ergonode\Value\Domain\Event\ValueChangedEvent;
 use Ramsey\Uuid\Uuid;
+use Ergonode\Attribute\Domain\Query\AttributeQueryInterface;
+use Webmozart\Assert\Assert;
 
 class DbalValueChangedEventProjector
 {
@@ -25,10 +26,16 @@ class DbalValueChangedEventProjector
 
     private SerializerInterface $serializer;
 
-    public function __construct(Connection $connection, SerializerInterface $serializer)
-    {
+    private AttributeQueryInterface $attributeQuery;
+
+    public function __construct(
+        Connection $connection,
+        SerializerInterface $serializer,
+        AttributeQueryInterface $attributeQuery
+    ) {
         $this->connection = $connection;
         $this->serializer = $serializer;
+        $this->attributeQuery = $attributeQuery;
     }
 
     /**
@@ -37,7 +44,8 @@ class DbalValueChangedEventProjector
     public function __invoke(ValueChangedEvent $event): void
     {
         $this->connection->transactional(function () use ($event): void {
-            $attributeId = AttributeId::fromKey($event->getAttributeCode()->getValue());
+            $attributeId = $this->attributeQuery->findAttributeIdByCode($event->getAttributeCode());
+            Assert::notNull($attributeId);
             $type = get_class($event->getTo());
             $newValue = $this->serializer->serialize($event->getTo());
             $oldValue = $this->serializer->serialize($event->getTo());

--- a/module/workflow/src/Domain/Entity/Attribute/StatusSystemAttribute.php
+++ b/module/workflow/src/Domain/Entity/Attribute/StatusSystemAttribute.php
@@ -33,7 +33,7 @@ class StatusSystemAttribute extends AbstractAttribute
         TranslatableString $placeholder
     ) {
         $code = new AttributeCode(self::CODE);
-        $id = AttributeId::fromKey($code->getValue());
+        $id = AttributeId::generate();
         $scope = new AttributeScope(AttributeScope::LOCAL);
 
         parent::__construct($id, $code, $label, $hint, $placeholder, $scope);

--- a/module/workflow/src/Infrastructure/Query/ProductWorkflowQuery.php
+++ b/module/workflow/src/Infrastructure/Query/ProductWorkflowQuery.php
@@ -11,13 +11,13 @@ namespace Ergonode\Workflow\Infrastructure\Query;
 use Ergonode\Workflow\Domain\Entity\Attribute\StatusSystemAttribute;
 use Ergonode\SharedKernel\Domain\Aggregate\StatusId;
 use Webmozart\Assert\Assert;
-use Ergonode\SharedKernel\Domain\Aggregate\AttributeId;
 use Ergonode\Workflow\Domain\Repository\StatusRepositoryInterface;
 use Ergonode\Workflow\Domain\Service\StatusCalculationService;
 use Ergonode\Product\Domain\Entity\AbstractProduct;
 use Ergonode\Core\Domain\ValueObject\Language;
 use Ergonode\Workflow\Domain\Entity\AbstractWorkflow;
 use Ergonode\Attribute\Domain\ValueObject\AttributeCode;
+use Ergonode\Attribute\Domain\Query\AttributeQueryInterface;
 
 class ProductWorkflowQuery
 {
@@ -25,12 +25,16 @@ class ProductWorkflowQuery
 
     private StatusCalculationService $service;
 
+    private AttributeQueryInterface $attributeQuery;
+
     public function __construct(
         StatusRepositoryInterface $statusRepository,
-        StatusCalculationService $service
+        StatusCalculationService $service,
+        AttributeQueryInterface $attributeQuery
     ) {
         $this->statusRepository = $statusRepository;
         $this->service = $service;
+        $this->attributeQuery = $attributeQuery;
     }
 
     /**
@@ -47,13 +51,14 @@ class ProductWorkflowQuery
         $code = new AttributeCode(StatusSystemAttribute::CODE);
         $result = [];
         if ($product->hasAttribute($code)) {
+            $attributeId = $this->attributeQuery->findAttributeIdByCode($code);
+            Assert::notNull($attributeId, sprintf('attribute %s not exists', $attributeId->getValue()));
             $value = $product->getAttribute($code)->getValue();
             $statusId = new StatusId($value[$productLanguage->getCode()]);
             $status = $this->statusRepository->load($statusId);
             Assert::notNull($status, sprintf('status %s not exists', $statusId->getValue()));
             $result['status'] = [
-                'attribute_id' =>
-                    AttributeId::fromKey((new AttributeCode(StatusSystemAttribute::CODE))->getValue()),
+                'attribute_id' => $attributeId->getValue(),
                 'id' => $status->getId()->getValue(),
                 'name' => $status->getName()->get($language),
                 'code' => $status->getCode()->getValue(),

--- a/src/Resources/fixtures/develop/templates.yaml
+++ b/src/Resources/fixtures/develop/templates.yaml
@@ -43,7 +43,7 @@ Ergonode\Designer\Domain\Entity\Element\AttributeTemplateElement:
         __construct:
             - '@position_<current()>'
             - '@size'
-            - '<AttributeId(code_<current()>)>'
+            - '@attribute_<current()>->id'
             
 Ergonode\Designer\Domain\Entity\Element\UiTemplateElement:
     template_element_8:


### PR DESCRIPTION
# Description

Remove all usages of AttributeId::fromKey from application and mark method as deprecated

Issue #1736
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!--  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit Tests
- [ ] Behat Test

# Checklist:
- [x] I have read the contribution requirements and fulfill them.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
