### PR TITLE
feature(value) add getTransation and hasTransation method to ValueInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - refactor [#1736](https://github.com/ergonode/backend/issues/1736) Make AttributeId::fromKey method deprecated (rprzedzik)
 - feature [#1749](https://github.com/ergonode/backend/issues/1749) Add guzzleDownloader base on DownloaderInterface (rprzedzik)
 - feature [#1747](https://github.com/ergonode/backend/issues/1747) Test modules configuration (piotrkreft)
+- feature [#1756](https://github.com/ergonode/backend/issues/1756) Extension of ValueInterface and unification of implemented classes (rprzedzik)
 
 ## CHANGELOG FOR 1.2.x
 #### 1.2.0

--- a/UPGRADE-1.3.md
+++ b/UPGRADE-1.3.md
@@ -14,3 +14,6 @@ Attribute:
 
 Core
 * `DownloaderInterface::download` throws exception rather than returning `null` value
+
+Value
+* `getTransation` and `hasTransation` methods are added to `Ergonode\Value\Domain\ValueObject\ValueInterface`

--- a/module/value/src/Domain/ValueObject/StringCollectionValue.php
+++ b/module/value/src/Domain/ValueObject/StringCollectionValue.php
@@ -44,6 +44,12 @@ class StringCollectionValue implements ValueInterface
 
     public function getTranslation(Language $language): ?string
     {
+        if (!$this->hasTranslation($language)) {
+            throw new \InvalidArgumentException(
+                sprintf('Value for language %s not exists', $language->getCode())
+            );
+        }
+
         return $this->value[$language->getCode()] ?? null;
     }
 

--- a/module/value/src/Domain/ValueObject/StringCollectionValue.php
+++ b/module/value/src/Domain/ValueObject/StringCollectionValue.php
@@ -47,6 +47,11 @@ class StringCollectionValue implements ValueInterface
         return $this->value[$language->getCode()] ?? null;
     }
 
+    public function hasTranslation(Language $language): bool
+    {
+        return array_key_exists($language->getCode(), $this->value);
+    }
+
     public function merge(ValueInterface $value): self
     {
         Assert::isInstanceOf($value, self::class);
@@ -54,9 +59,6 @@ class StringCollectionValue implements ValueInterface
         return new self(array_merge($this->value, $value->getValue()));
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function __toString(): string
     {
         return implode(',', $this->value);

--- a/module/value/src/Domain/ValueObject/StringValue.php
+++ b/module/value/src/Domain/ValueObject/StringValue.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Ergonode\Value\Domain\ValueObject;
 
 use Webmozart\Assert\Assert;
+use Ergonode\Core\Domain\ValueObject\Language;
 
 class StringValue implements ValueInterface
 {
@@ -39,6 +40,16 @@ class StringValue implements ValueInterface
         return [null => $this->value];
     }
 
+    public function getTranslation(Language $language): ?string
+    {
+        return $this->value;
+    }
+
+    public function hasTranslation(Language $language): bool
+    {
+        return true;
+    }
+
     public function merge(ValueInterface $value): self
     {
         Assert::isInstanceOf($value, self::class);
@@ -46,9 +57,6 @@ class StringValue implements ValueInterface
         return new self((string) $value);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function __toString(): string
     {
         return $this->value;

--- a/module/value/src/Domain/ValueObject/TranslatableStringValue.php
+++ b/module/value/src/Domain/ValueObject/TranslatableStringValue.php
@@ -39,6 +39,12 @@ class TranslatableStringValue implements ValueInterface
 
     public function getTranslation(Language $language): ?string
     {
+        if (!$this->hasTranslation($language)) {
+            throw new \InvalidArgumentException(
+                sprintf('Value for language %s not exists', $language->getCode())
+            );
+        }
+
         return $this->value->get($language);
     }
 

--- a/module/value/src/Domain/ValueObject/TranslatableStringValue.php
+++ b/module/value/src/Domain/ValueObject/TranslatableStringValue.php
@@ -42,6 +42,11 @@ class TranslatableStringValue implements ValueInterface
         return $this->value->get($language);
     }
 
+    public function hasTranslation(Language $language): bool
+    {
+        return $this->value->has($language);
+    }
+
     public function merge(ValueInterface $value): self
     {
         Assert::isInstanceOf($value, self::class);
@@ -49,9 +54,6 @@ class TranslatableStringValue implements ValueInterface
         return new self(new TranslatableString(array_merge($this->value->getTranslations(), $value->getValue())));
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function __toString(): string
     {
         return implode(',', $this->value->getTranslations());

--- a/module/value/src/Domain/ValueObject/ValueInterface.php
+++ b/module/value/src/Domain/ValueObject/ValueInterface.php
@@ -22,6 +22,9 @@ interface ValueInterface
 
     public function getType(): string;
 
+    /**
+     * @throws \InvalidArgumentException
+     */
     public function getTranslation(Language $language): ?string;
 
     public function hasTranslation(Language $language): bool;

--- a/module/value/src/Domain/ValueObject/ValueInterface.php
+++ b/module/value/src/Domain/ValueObject/ValueInterface.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Ergonode\Value\Domain\ValueObject;
 
+use Ergonode\Core\Domain\ValueObject\Language;
+
 interface ValueInterface
 {
     public const NAMESPACE = 'cb2600df-94fb-4755-9e6a-a15591a8e510';
@@ -19,6 +21,10 @@ interface ValueInterface
     public function getValue(): array;
 
     public function getType(): string;
+
+    public function getTranslation(Language $language): ?string;
+
+    public function hasTranslation(Language $language): bool;
 
     public function __toString(): string;
 

--- a/module/value/tests/Domain/ValueObject/StringCollectionValueTest.php
+++ b/module/value/tests/Domain/ValueObject/StringCollectionValueTest.php
@@ -19,17 +19,38 @@ class StringCollectionValueTest extends TestCase
 {
     public function testValueCreation(): void
     {
-        $value = ['pl_PL' => 'value1', 'en_GB' => 'value2'];
+        $language1 = new Language('pl_PL');
+        $language2 = new Language('en_GB');
+
+        $value1 = 'value1';
+        $value2 = 'value2';
+
+        $value = [$language1->getCode() => $value1, $language2->getCode() => $value2];
 
         $valueObject1 = new StringCollectionValue($value);
 
         $valueObject2 = new StringCollectionValue($value);
 
         self::assertSame($value, $valueObject1->getValue());
+        self::assertSame($value1, $valueObject1->getTranslation($language1));
         self::assertSame(StringCollectionValue::TYPE, $valueObject1->getType());
-        self::assertSame('value1', $valueObject1->getTranslation(new Language('pl_PL')));
-        self::assertSame("value1,value2", (string) $valueObject1);
+        self::assertSame($value1, $valueObject1->getTranslation($language1));
+        self::assertSame($value2, $valueObject1->getTranslation($language2));
+        self::assertTrue($valueObject1->hasTranslation($language1));
+        self::assertTrue($valueObject1->hasTranslation($language2));
+        self::assertSame("$value1,$value2", (string) $valueObject1);
         self::assertTrue($valueObject1->isEqual($valueObject2));
+    }
+
+    public function testNotExistValueException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $language = new Language('en_GB');
+
+        $value = new StringCollectionValue([]);
+        self::assertFalse($value->hasTranslation($language));
+        $value->getTranslation($language);
     }
 
     public function testMergeInvalidValueObject(): void

--- a/module/value/tests/Domain/ValueObject/StringValueTest.php
+++ b/module/value/tests/Domain/ValueObject/StringValueTest.php
@@ -12,18 +12,22 @@ namespace Ergonode\Value\Tests\Domain\ValueObject;
 use Ergonode\Value\Domain\ValueObject\StringValue;
 use PHPUnit\Framework\TestCase;
 use Ergonode\Value\Domain\ValueObject\ValueInterface;
+use Ergonode\Core\Domain\ValueObject\Language;
 
 class StringValueTest extends TestCase
 {
     public function testValueCreation(): void
     {
+        $language = $this->createMock(Language::class);
         $value = 'string';
 
         $valueObject1 = new StringValue($value);
         $valueObject2 = new StringValue($value);
 
         $this->assertSame($value, $valueObject1->getValue()[null]);
+        $this->assertSame($value, $valueObject1->getTranslation($language));
         $this->assertSame(StringValue::TYPE, $valueObject1->getType());
+        $this->assertTrue($valueObject1->hasTranslation($language));
         $this->assertSame($value, (string) $valueObject1);
         $this->assertTrue($valueObject1->isEqual($valueObject2));
     }

--- a/module/value/tests/Domain/ValueObject/TranslatableStringValueTest.php
+++ b/module/value/tests/Domain/ValueObject/TranslatableStringValueTest.php
@@ -20,7 +20,14 @@ class TranslatableStringValueTest extends TestCase
 {
     public function testValueCreation(): void
     {
-        $array = ['en_GB' => 'english', 'pl_PL' => 'polish'];
+        $language1 = new Language('en_GB');
+        $language2 = new Language('pl_PL');
+
+        $value1 = 'english';
+        $value2 = 'polish';
+
+        $array = [$language1->getCode() => $value1, $language2->getCode() => $value2];
+
         $value = new TranslatableString($array);
 
         $valueObject1 = new TranslatableStringValue($value);
@@ -28,9 +35,25 @@ class TranslatableStringValueTest extends TestCase
 
         self::assertSame($array, $valueObject1->getValue());
         self::assertSame(TranslatableStringValue::TYPE, $valueObject1->getType());
-        self::assertSame('polish', $valueObject1->getTranslation(new Language('pl_PL')));
+        self::assertSame($value2, $valueObject1->getTranslation($language2));
         self::assertSame("english,polish", (string) $valueObject1);
+        self::assertSame($value1, $valueObject1->getTranslation($language1));
+        self::assertSame($value2, $valueObject1->getTranslation($language2));
+        self::assertTrue($valueObject1->hasTranslation($language1));
+        self::assertTrue($valueObject1->hasTranslation($language2));
+        self::assertSame("$value1,$value2", (string) $valueObject1);
         self::assertTrue($valueObject1->isEqual($valueObject2));
+    }
+
+    public function testNotExistValueException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $language = new Language('en_GB');
+
+        $value = new TranslatableStringValue(new TranslatableString());
+        self::assertFalse($value->hasTranslation($language));
+        $value->getTranslation($language);
     }
 
     public function testMergeInvalidValueObject(): void


### PR DESCRIPTION
# Description

Add `getTransation` and `hasTransation` methods to `ValueInterface` and unification of classes used this interface

Issue #1756
## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!--  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Unit Tests
- [ ] Behat Test

# Checklist:
- [x] I have read the contribution requirements and fulfill them.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
